### PR TITLE
Handle QNAME in answers

### DIFF
--- a/src/cname_tracker.h
+++ b/src/cname_tracker.h
@@ -17,7 +17,7 @@ public:
 
   virtual void                  clear() = 0;
 
-  virtual ~CnameTracker() {};  // virtual destructor hint needed for most c++ compilers.
+  virtual ~CnameTracker() {}  // virtual destructor hint needed for most c++ compilers.
 };
 
 /**

--- a/src/dnsparse.cpp
+++ b/src/dnsparse.cpp
@@ -243,7 +243,7 @@ int DnsParserImpl::dnsReadAnswers(char *payload, int payloadLen, char *ptr, int 
       case DNS_ANS_TYPE_A:
       {
         in_addr addr;
-        addr.s_addr = *((uint32_t *)(p + sizeof(ans)));
+        addr.s_addr = *((uint32_t *)(p + sizeof(ans) + fieldsOffset));
 
         if (_ignoreCnames) {
           if (0L != _listener) _listener->onDnsRec(addr, firstName, "");
@@ -260,7 +260,7 @@ int DnsParserImpl::dnsReadAnswers(char *payload, int payloadLen, char *ptr, int 
       case DNS_ANS_TYPE_AAAA:
       {
         in6_addr addr;
-        memcpy(&addr, p+sizeof(ans), sizeof(addr));
+        memcpy(&addr, p+sizeof(ans)+fieldsOffset, sizeof(addr));
 
         if (_ignoreCnames) {
           if (0L != _listener)


### PR DESCRIPTION
Some DNS servers (like Quad9) return answers with a name field as a QNAME instead of a pointer. This checks for this type of answer, and parses the name and other answer fields accordingly.